### PR TITLE
Fix table in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The data is hold and shared by a collaborative cluster, where everyone can parti
 | `123...` | | Guthrie, Oklahoma | Cox Communications Inc | AS22773 | [@teknomunk](https://github.com/teknomunk) |
 | `12D3KooWJnEkuYkoWgfGBjQXE6bvn6Y53GmjwuC2vk7d2Xxk9xM5` | `vidar.pacman.store` | Vilnius, Lithuania | UAB Interneto vizija | AS20080814 | [@RubenKelevra](https://github.com/@RubenKelevra) |
 | `12D3KooWKSDCCB1Aw5jV4UoVxcnoCA1rAbjAKKys5KbZqJCsNaFM` | `heimdal.pacman.store` | Mumbai, India | Oracle Corporation | AS31898 | [@RubenKelevra](https://github.com/@RubenKelevra) |
-| `123...` | | ~ Tokyo, Japan | | AS7506 | _anonymous_
+| `123...` | | ~ Tokyo, Japan | | AS7506 | _anonymous_ |
 
 
 ## Import Server uptime (since 2020-07-02)


### PR DESCRIPTION
Without this symbol at the end, GitHub renders the table without a line at the bottom.