### PR TITLE
Add new cluster follower peer

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The data is hold and shared by a collaborative cluster, where everyone can parti
 | `12D3KooWJnEkuYkoWgfGBjQXE6bvn6Y53GmjwuC2vk7d2Xxk9xM5` | `vidar.pacman.store` | Vilnius, Lithuania | UAB Interneto vizija | AS20080814 | [@RubenKelevra](https://github.com/@RubenKelevra) |
 | `12D3KooWKSDCCB1Aw5jV4UoVxcnoCA1rAbjAKKys5KbZqJCsNaFM` | `heimdal.pacman.store` | Mumbai, India | Oracle Corporation | AS31898 | [@RubenKelevra](https://github.com/@RubenKelevra) |
 | `123...` | | ~ Tokyo, Japan | | AS7506 | _anonymous_ |
+| `12D3KooWBqQrnTqx9Wp89p2bD1hrwmXYJQ5x1fDfigRCfZJGKQfr` | `luflosi.de` | Saarland, Germany | VSE NET GmbH | AS9063 | [@Luflosi](https://github.com/@Luflosi) |
 
 
 ## Import Server uptime (since 2020-07-02)

--- a/collab-cluster-config/lowpower.json
+++ b/collab-cluster-config/lowpower.json
@@ -25,7 +25,8 @@
       "/ip6/2a03:4000:46:26e:b42e:2bff:fe07:c3fb/tcp/16587/p2p/12D3KooWDM4BGmkaxhLtEFbQJekdBHtWHo3ELUL4HE9f4DdNbGZx",
       "/ip4/94.176.233.122/tcp/16587/p2p/12D3KooWJnEkuYkoWgfGBjQXE6bvn6Y53GmjwuC2vk7d2Xxk9xM5",
       "/ip6/2a02:7b40:5eb0:e97a::1/tcp/16587/p2p/12D3KooWJnEkuYkoWgfGBjQXE6bvn6Y53GmjwuC2vk7d2Xxk9xM5",
-      "/ip4/140.238.249.171/tcp/16587/p2p/12D3KooWN9pSnzmE57cN4XDoYPRs1htjSRF2ig528kwb3VRrvf1Z"
+      "/ip4/140.238.249.171/tcp/16587/p2p/12D3KooWN9pSnzmE57cN4XDoYPRs1htjSRF2ig528kwb3VRrvf1Z",
+      "/dns4/luflosi.de/udp/4001/quic/p2p/12D3KooWBqQrnTqx9Wp89p2bD1hrwmXYJQ5x1fDfigRCfZJGKQfr"
     ]
   },
   "consensus": {

--- a/collab-cluster-config/service.json
+++ b/collab-cluster-config/service.json
@@ -25,7 +25,8 @@
       "/ip6/2a03:4000:46:26e:b42e:2bff:fe07:c3fb/tcp/16587/p2p/12D3KooWDM4BGmkaxhLtEFbQJekdBHtWHo3ELUL4HE9f4DdNbGZx",
       "/ip4/94.176.233.122/tcp/16587/p2p/12D3KooWJnEkuYkoWgfGBjQXE6bvn6Y53GmjwuC2vk7d2Xxk9xM5",
       "/ip6/2a02:7b40:5eb0:e97a::1/tcp/16587/p2p/12D3KooWJnEkuYkoWgfGBjQXE6bvn6Y53GmjwuC2vk7d2Xxk9xM5",
-      "/ip4/140.238.249.171/tcp/16587/p2p/12D3KooWN9pSnzmE57cN4XDoYPRs1htjSRF2ig528kwb3VRrvf1Z"
+      "/ip4/140.238.249.171/tcp/16587/p2p/12D3KooWN9pSnzmE57cN4XDoYPRs1htjSRF2ig528kwb3VRrvf1Z",
+      "/dns4/luflosi.de/udp/4001/quic/p2p/12D3KooWBqQrnTqx9Wp89p2bD1hrwmXYJQ5x1fDfigRCfZJGKQfr"
     ]
   },
   "consensus": {


### PR DESCRIPTION
Add myself to the list of cluster members.

On a slightly unrelated note, I would like to ask why the table in the README and the peer_addresses are so different. The README for example lists the peer 12D3KooWKSDCCB1Aw5jV4UoVxcnoCA1rAbjAKKys5KbZqJCsNaFM, which is not in peer_addresses and the peer 12D3KooWN9pSnzmE57cN4XDoYPRs1htjSRF2ig528kwb3VRrvf1Z is in peer_addresses but not in the README.